### PR TITLE
fix: correct fullWidthImages setting to use width instead of max-width

### DIFF
--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -71,8 +71,8 @@ export function useSettings({ relayPool, eventStore, pubkey, accountManager }: U
       // Set paragraph alignment
       root.setProperty('--paragraph-alignment', settings.paragraphAlignment || 'justify')
       
-      // Set image max-width based on full-width setting
-      root.setProperty('--image-max-width', settings.fullWidthImages ? 'none' : '100%')
+      // Set image width based on full-width setting
+      root.setProperty('--image-width', settings.fullWidthImages ? '100%' : 'auto')
       
     }
     

--- a/src/styles/components/reader.css
+++ b/src/styles/components/reader.css
@@ -57,10 +57,10 @@
 .reader .reader-markdown h1, .reader .reader-markdown h2, .reader .reader-markdown h3, .reader .reader-markdown h4, .reader .reader-markdown h5, .reader .reader-markdown h6 { text-align: left !important; }
 /* Tame images from external content */
 .reader .reader-html img, .reader .reader-markdown img { 
-  max-width: var(--image-max-width, 100%); 
+  width: var(--image-width, auto);
+  max-width: 100%; 
   max-height: 70vh; 
   height: auto; 
-  width: auto; 
   display: block; 
   margin: 0.75rem auto; 
   border-radius: 6px; 
@@ -192,8 +192,8 @@
   }
   
   .reader-markdown img, .reader-html img {
+    width: var(--image-width, auto) !important;
     max-width: 100% !important;
-    width: auto !important;
     height: auto;
   }
 }


### PR DESCRIPTION
Fixes the fullWidthImages setting implementation. Previously, when enabled, it set `max-width: none` which allowed images to exceed 100% container width. The setting now correctly sets images to `width: 100%` when enabled, enlarging smaller images to full width while maintaining aspect ratio, and always constrains with `max-width: 100%` to prevent overflow.

- Changed from `--image-max-width` CSS variable to `--image-width` to control actual width
- When enabled, sets `width: 100%` instead of removing max-width constraint
- Updated both main reader styles and mobile responsive overrides
