### PR TITLE
Fix OpenGraph meta tags for article URLs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,13 +2,6 @@
   "rewrites": [
     {
       "source": "/a/:naddr",
-      "has": [
-        {
-          "type": "header",
-          "key": "user-agent",
-          "value": ".*(bot|crawl|spider|slurp|facebook|twitter|linkedin|whatsapp|telegram|slack|discord|preview).*"
-        }
-      ],
       "destination": "/api/article-og?naddr=:naddr"
     },
     {


### PR DESCRIPTION
Fix OpenGraph meta tags for article URLs by removing the user-agent restriction from the Vercel rewrite rule. All requests to `/a/:naddr` now route to the `article-og` handler, which handles crawler detection internally and serves proper OpenGraph tags with title, description, and image for social media crawlers.

- Remove `has` condition from `/a/:naddr` rewrite rule in `vercel.json`
- Let `article-og.ts` handler handle all crawler detection and routing
- Ensures social media crawlers always receive proper meta tags instead of empty ones
