### PR TITLE
Cache decrypted content for hidden bookmarks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import { loadUserRelayList, loadBlockedRelays, computeRelaySet } from './service
 import { applyRelaySetToPool, getActiveRelayUrls, ALWAYS_LOCAL_RELAYS, HARDCODED_RELAYS } from './services/relayManager'
 import { Bookmark } from './types/bookmarks'
 import { bookmarkController } from './services/bookmarkController'
-import { startEncryptedContentCache } from './services/encryptedContentCache'
+import { startEncryptedContentCache, clearEncryptedContentCache } from './services/encryptedContentCache'
 import { contactsController } from './services/contactsController'
 import { highlightsController } from './services/highlightsController'
 import { writingsController } from './services/writingsController'
@@ -157,6 +157,7 @@ function AppRoutes({
     highlightsController.reset() // Clear highlights via controller
     readingProgressController.reset() // Clear reading progress via controller
     archiveController.reset() // Clear archive state
+    clearEncryptedContentCache() // Clear cached decrypted content
     showToast('Logged out successfully')
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { loadUserRelayList, loadBlockedRelays, computeRelaySet } from './service
 import { applyRelaySetToPool, getActiveRelayUrls, ALWAYS_LOCAL_RELAYS, HARDCODED_RELAYS } from './services/relayManager'
 import { Bookmark } from './types/bookmarks'
 import { bookmarkController } from './services/bookmarkController'
+import { startEncryptedContentCache } from './services/encryptedContentCache'
 import { contactsController } from './services/contactsController'
 import { highlightsController } from './services/highlightsController'
 import { writingsController } from './services/writingsController'
@@ -390,6 +391,10 @@ function App() {
     const initializeApp = async () => {
       // Initialize event store, account manager, and relay pool
       const store = new EventStore({ deleteManager: new DeleteManager() })
+      
+      // Cache decrypted content so hidden bookmarks don't need re-decryption on every load
+      const stopEncryptedContentCache = startEncryptedContentCache(store)
+      
       const accounts = new AccountManager()
       
       // Disable request queueing globally - makes all operations instant
@@ -697,6 +702,7 @@ function App() {
       
       // Cleanup function
       return () => {
+        stopEncryptedContentCache()
         accountsSub.unsubscribe()
         activeSub.unsubscribe()
         bunkerReconnectSub.unsubscribe()

--- a/src/services/bookmarkController.ts
+++ b/src/services/bookmarkController.ts
@@ -458,6 +458,11 @@ class BookmarkController {
             // Add/update event
             this.currentEvents.set(key, evt)
             
+            // Add to event store so persistEncryptedContent can restore cached decrypted content
+            if (this.externalEventStore) {
+              this.externalEventStore.add(evt)
+            }
+            
             // Emit raw event for Debug UI
             this.emitRawEvent(evt)
             

--- a/src/services/encryptedContentCache.ts
+++ b/src/services/encryptedContentCache.ts
@@ -1,0 +1,33 @@
+import { persistEncryptedContent, EncryptedContentCache } from 'applesauce-common/helpers'
+import { IEventStoreStreams } from 'applesauce-core/event-store'
+
+const STORAGE_PREFIX = 'boris-encrypted-content:'
+
+/**
+ * A localStorage-backed cache for decrypted event content.
+ * Implements the EncryptedContentCache interface from applesauce-common.
+ */
+const encryptedContentStorage: EncryptedContentCache = {
+  async getItem(key: string): Promise<string | null> {
+    try {
+      return localStorage.getItem(STORAGE_PREFIX + key)
+    } catch {
+      return null
+    }
+  },
+  async setItem(key: string, value: string): Promise<void> {
+    try {
+      localStorage.setItem(STORAGE_PREFIX + key, value)
+    } catch {
+      // Storage full or unavailable, ignore
+    }
+  }
+}
+
+/**
+ * Start persisting and restoring encrypted content for the given event store.
+ * Returns a cleanup function that stops the persistence process.
+ */
+export function startEncryptedContentCache(eventStore: IEventStoreStreams): () => void {
+  return persistEncryptedContent(eventStore, encryptedContentStorage)
+}

--- a/src/services/encryptedContentCache.ts
+++ b/src/services/encryptedContentCache.ts
@@ -6,6 +6,10 @@ const STORAGE_PREFIX = 'boris-encrypted-content:'
 /**
  * A localStorage-backed cache for decrypted event content.
  * Implements the EncryptedContentCache interface from applesauce-common.
+ *
+ * Note: decrypted content is stored as plaintext in localStorage, which
+ * persists across browser restarts and is readable by any script on the
+ * same origin. The cache is cleared on logout via clearEncryptedContentCache().
  */
 const encryptedContentStorage: EncryptedContentCache = {
   async getItem(key: string): Promise<string | null> {
@@ -30,4 +34,25 @@ const encryptedContentStorage: EncryptedContentCache = {
  */
 export function startEncryptedContentCache(eventStore: IEventStoreStreams): () => void {
   return persistEncryptedContent(eventStore, encryptedContentStorage)
+}
+
+/**
+ * Clear all cached decrypted content from localStorage.
+ * Call on logout to avoid leaving plaintext content behind.
+ */
+export function clearEncryptedContentCache(): void {
+  try {
+    const keysToRemove: string[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (key && key.startsWith(STORAGE_PREFIX)) {
+        keysToRemove.push(key)
+      }
+    }
+    for (const key of keysToRemove) {
+      localStorage.removeItem(key)
+    }
+  } catch {
+    // localStorage unavailable, nothing to clear
+  }
 }


### PR DESCRIPTION
Integrates applesauce's `persistEncryptedContent` helper to cache decrypted event content in localStorage. Previously, hidden bookmarks were decrypted on every page load, requiring a round-trip to the signer each time. Now, once an event is decrypted, the plaintext content is cached locally and restored automatically when the same event is loaded again.

- Added `encryptedContentCache.ts` service with a localStorage-backed `EncryptedContentCache` implementation
- Wired up `persistEncryptedContent(eventStore, storage)` in `App.tsx` at EventStore initialization
- Bookmark list events are now added to the event store so the cache can track and restore their decrypted content


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encrypted content caching with persistent local storage to preserve decrypted content across sessions.
  * Automatic cache initialization at app start and robust cleanup on logout/teardown.
  * Event streaming now persists newly added or updated items immediately, improving cache restoration on reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->