### PR TITLE
fix: avoid article og serverless crashes

### DIFF
--- a/api/services/articleMeta.ts
+++ b/api/services/articleMeta.ts
@@ -5,6 +5,17 @@ const DEFAULT_SUMMARY = 'Read this article on Boris'
 const DEFAULT_IMAGE = '/boris-social-1200.png'
 const DEFAULT_AUTHOR = 'Boris'
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function metaPattern(attribute: 'name' | 'property', value: string): RegExp {
+  return new RegExp(
+    `<meta(?=[^>]*\\b${attribute}=["']${escapeRegExp(value)}["'])(?=[^>]*\\bcontent=["']([^"']+)["'])[^>]*>`,
+    'i'
+  )
+}
+
 function pickMeta(html: string, patterns: RegExp[]): string {
   for (const pattern of patterns) {
     const match = html.match(pattern)
@@ -39,25 +50,25 @@ export async function fetchArticleMetadataViaGateway(naddr: string): Promise<Art
       const html = await resp.text()
 
       const title = pickMeta(html, [
-        /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']+)["']/i,
-        /<meta[^>]+name=["']twitter:title["'][^>]+content=["']([^"']+)["']/i,
+        metaPattern('property', 'og:title'),
+        metaPattern('name', 'twitter:title'),
         /<title[^>]*>([^<]+)<\/title>/i
       ])
 
       const summary = pickMeta(html, [
-        /<meta[^>]+property=["']og:description["'][^>]+content=["']([^"']+)["']/i,
-        /<meta[^>]+name=["']twitter:description["'][^>]+content=["']([^"']+)["']/i,
-        /<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["']/i
+        metaPattern('property', 'og:description'),
+        metaPattern('name', 'twitter:description'),
+        metaPattern('name', 'description')
       ])
 
       const image = pickMeta(html, [
-        /<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i,
-        /<meta[^>]+name=["']twitter:image["'][^>]+content=["']([^"']+)["']/i
+        metaPattern('property', 'og:image'),
+        metaPattern('name', 'twitter:image')
       ])
 
       const author = pickMeta(html, [
-        /<meta[^>]+property=["']article:author["'][^>]+content=["']([^"']+)["']/i,
-        /<meta[^>]+name=["']author["'][^>]+content=["']([^"']+)["']/i
+        metaPattern('property', 'article:author'),
+        metaPattern('name', 'author')
       ])
 
       if (!title && !summary && !image) {

--- a/api/services/articleMeta.ts
+++ b/api/services/articleMeta.ts
@@ -1,228 +1,85 @@
-import WebSocket from 'ws'
-;(globalThis as unknown as { WebSocket?: typeof WebSocket }).WebSocket ??= WebSocket
-import { RelayPool } from 'applesauce-relay'
-import { nip19 } from 'nostr-tools'
-import { AddressPointer } from 'nostr-tools/nip19'
-import { NostrEvent, Filter } from 'nostr-tools'
-import { Helpers } from 'applesauce-core'
-import { extractProfileDisplayName } from '../../lib/profile.js'
-import { RELAYS } from '../../src/config/relays.js'
 import type { ArticleMetadata } from './ogStore.js'
 
-const { getArticleTitle, getArticleImage, getArticleSummary } = Helpers
+const DEFAULT_TITLE = 'Read on Boris'
+const DEFAULT_SUMMARY = 'Read this article on Boris'
+const DEFAULT_IMAGE = '/boris-social-1200.png'
+const DEFAULT_AUTHOR = 'Boris'
 
-const isNotLocalhostRelay = (url: string): boolean =>
-  !url.includes('localhost') && !url.includes('127.0.0.1')
-
-const SERVERLESS_RELAYS = RELAYS.filter(isNotLocalhostRelay)
-
-async function fetchEventsFromRelays(
-  relayPool: RelayPool,
-  relayUrls: string[],
-  filter: Filter,
-  timeoutMs: number
-): Promise<NostrEvent[]> {
-  const events: NostrEvent[] = []
-
-  await new Promise<void>((resolve) => {
-    const timeout = setTimeout(() => resolve(), timeoutMs)
-
-    const subscription = relayPool.request(relayUrls, filter).subscribe({
-      next: (event) => {
-        events.push(event)
-      },
-      error: () => {
-        clearTimeout(timeout)
-        subscription?.unsubscribe()
-        resolve()
-      },
-      complete: () => {
-        clearTimeout(timeout)
-        resolve()
-      }
-    })
-  })
-
-  return events.sort((a, b) => b.created_at - a.created_at)
-}
-
-async function fetchFirstEvent(
-  relayPool: RelayPool,
-  relayUrls: string[],
-  filter: Filter,
-  timeoutMs: number
-): Promise<NostrEvent | null> {
-  return new Promise<NostrEvent | null>((resolve) => {
-    let resolved = false
-    const timeout = setTimeout(() => {
-      if (!resolved) {
-        resolved = true
-        resolve(null)
-      }
-    }, timeoutMs)
-
-    const subscription = relayPool.request(relayUrls, filter).subscribe({
-      next: (event) => {
-        if (!resolved) {
-          resolved = true
-          clearTimeout(timeout)
-          subscription.unsubscribe()
-          resolve(event)
-        }
-      },
-      error: () => {
-        if (!resolved) {
-          resolved = true
-          clearTimeout(timeout)
-          resolve(null)
-        }
-      },
-      complete: () => {
-        if (!resolved) {
-          resolved = true
-          clearTimeout(timeout)
-          resolve(null)
-        }
-      }
-    })
-  })
-}
-
-async function fetchAuthorProfile(
-  relayPool: RelayPool,
-  relayUrls: string[],
-  pubkey: string,
-  timeoutMs: number
-): Promise<string | null> {
-  const profileEvents = await fetchEventsFromRelays(relayPool, relayUrls, {
-    kinds: [0],
-    authors: [pubkey]
-  }, timeoutMs)
-
-  if (profileEvents.length === 0) {
-    return null
+function pickMeta(html: string, patterns: RegExp[]): string {
+  for (const pattern of patterns) {
+    const match = html.match(pattern)
+    if (match?.[1]) {
+      return match[1].trim()
+    }
   }
 
-  const displayName = extractProfileDisplayName(profileEvents[0])
-  if (displayName && !displayName.startsWith('@')) {
-    return displayName
-  } else if (displayName) {
-    return displayName.substring(1)
-  }
-
-  return null
-}
-
-export async function fetchArticleMetadataViaRelays(naddr: string): Promise<ArticleMetadata | null> {
-  const relayPool = new RelayPool()
-
-  try {
-    const decoded = nip19.decode(naddr)
-    if (decoded.type !== 'naddr') {
-      return null
-    }
-
-    const pointer = decoded.data as AddressPointer
-    const pointerRelays = pointer.relays?.filter(isNotLocalhostRelay)
-    const relayUrls = pointerRelays && pointerRelays.length > 0 ? pointerRelays : SERVERLESS_RELAYS
-
-    const article = await fetchFirstEvent(relayPool, relayUrls, {
-      kinds: [pointer.kind],
-      authors: [pointer.pubkey],
-      '#d': [pointer.identifier || '']
-    }, 7000)
-
-    if (!article) {
-      return null
-    }
-
-    const title = getArticleTitle(article) || 'Untitled Article'
-    const summary = getArticleSummary(article) || 'Read this article on Boris'
-    const image = getArticleImage(article) || '/boris-social-1200.png'
-
-    const tags = article.tags
-      ?.filter((tag) => tag[0] === 't' && tag[1])
-      .map((tag) => tag[1])
-      .filter((tag) => tag.length > 0) || []
-
-    const imageAlt = title || 'Article cover image'
-
-    let authorName = await fetchAuthorProfile(relayPool, relayUrls, pointer.pubkey, 400)
-
-    if (!authorName) {
-      authorName = await fetchAuthorProfile(relayPool, relayUrls, pointer.pubkey, 600)
-    }
-
-    if (!authorName) {
-      authorName = pointer.pubkey.slice(0, 8) + '...'
-    }
-
-    return {
-      title,
-      summary,
-      image,
-      author: authorName,
-      published: article.created_at,
-      tags: tags.length > 0 ? tags : undefined,
-      imageAlt
-    }
-  } catch (err) {
-    console.error('Failed to fetch article metadata via relays:', err)
-    return null
-  }
+  return ''
 }
 
 export async function fetchArticleMetadataViaGateway(naddr: string): Promise<ArticleMetadata | null> {
   try {
     const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), 2000)
-    
-    const url = `https://njump.to/${naddr}`
-    console.log(`Fetching from gateway: ${url}`)
-    
-    const resp = await fetch(url, { 
-      redirect: 'follow',
-      signal: controller.signal
-    })
-    clearTimeout(timeout)
-    
-    if (!resp.ok) {
-      console.error(`Gateway fetch failed: ${resp.status} ${resp.statusText} for ${url}`)
-      return null
-    }
-    
-    const html = await resp.text()
-    console.log(`Gateway response length: ${html.length} chars`)
-    
-    const pick = (re: RegExp) => {
-      const match = html.match(re)
-      return match?.[1] ? match[1].trim() : ''
-    }
-    
-    const title = pick(/<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']+)["']/i) || 
-                      pick(/<title[^>]*>([^<]+)<\/title>/i)
-    const summary = pick(/<meta[^>]+property=["']og:description["'][^>]+content=["']([^"']+)["']/i)
-    const image = pick(/<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i)
-    
-    console.log(`Parsed from gateway - title: ${title ? 'found' : 'missing'}, summary: ${summary ? 'found' : 'missing'}, image: ${image ? 'found' : 'missing'}`)
-    
-    if (!title && !summary && !image) {
-      console.log('No OG metadata found in gateway response')
-      return null
-    }
-    
-    return {
-      title: title || 'Read on Boris',
-      summary: summary || 'Read this article on Boris',
-      image: image || '/boris-social-1200.png',
-      author: 'Boris'
+    const timeout = setTimeout(() => controller.abort(), 4000)
+
+    try {
+      const url = `https://njump.to/${encodeURIComponent(naddr)}`
+      const resp = await fetch(url, {
+        redirect: 'follow',
+        signal: controller.signal,
+        headers: {
+          'user-agent': 'Boris OG fetcher'
+        }
+      })
+
+      if (!resp.ok) {
+        console.error(`Gateway fetch failed: ${resp.status} ${resp.statusText} for ${url}`)
+        return null
+      }
+
+      const html = await resp.text()
+
+      const title = pickMeta(html, [
+        /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']+)["']/i,
+        /<meta[^>]+name=["']twitter:title["'][^>]+content=["']([^"']+)["']/i,
+        /<title[^>]*>([^<]+)<\/title>/i
+      ])
+
+      const summary = pickMeta(html, [
+        /<meta[^>]+property=["']og:description["'][^>]+content=["']([^"']+)["']/i,
+        /<meta[^>]+name=["']twitter:description["'][^>]+content=["']([^"']+)["']/i,
+        /<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["']/i
+      ])
+
+      const image = pickMeta(html, [
+        /<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i,
+        /<meta[^>]+name=["']twitter:image["'][^>]+content=["']([^"']+)["']/i
+      ])
+
+      const author = pickMeta(html, [
+        /<meta[^>]+property=["']article:author["'][^>]+content=["']([^"']+)["']/i,
+        /<meta[^>]+name=["']author["'][^>]+content=["']([^"']+)["']/i
+      ])
+
+      if (!title && !summary && !image) {
+        console.log(`No OG metadata found via gateway for ${naddr}`)
+        return null
+      }
+
+      return {
+        title: title || DEFAULT_TITLE,
+        summary: summary || DEFAULT_SUMMARY,
+        image: image || DEFAULT_IMAGE,
+        author: author || DEFAULT_AUTHOR
+      }
+    } finally {
+      clearTimeout(timeout)
     }
   } catch (err) {
     console.error('Failed to fetch article metadata via gateway:', err)
-    if (err instanceof Error) {
-      console.error('Error details:', err.message, err.stack)
-    }
     return null
   }
 }
 
+export async function fetchArticleMetadataViaRelays(naddr: string): Promise<ArticleMetadata | null> {
+  return fetchArticleMetadataViaGateway(naddr)
+}

--- a/api/services/ogStore.ts
+++ b/api/services/ogStore.ts
@@ -11,7 +11,7 @@ if (!redisUrl || !redisToken) {
 
 const redisWrite = redisUrl && redisToken
   ? new Redis({ url: redisUrl, token: redisToken })
-  : Redis.fromEnv() // Fallback to fromEnv() if explicit vars not set
+  : null
 
 const redisRead = readOnlyToken && redisUrl
   ? new Redis({ url: redisUrl, token: readOnlyToken })
@@ -30,10 +30,18 @@ export type ArticleMetadata = {
 }
 
 export async function getArticleMeta(naddr: string): Promise<ArticleMetadata | null> {
+  if (!redisRead) {
+    return null
+  }
+
   return (await redisRead.get<ArticleMetadata>(keyOf(naddr))) || null
 }
 
 export async function setArticleMeta(naddr: string, meta: ArticleMetadata, ttlSec = 604800): Promise<void> {
+  if (!redisWrite) {
+    return
+  }
+
   await redisWrite.set(keyOf(naddr), meta, { ex: ttlSec })
 }
 

--- a/api/services/ogStore.ts
+++ b/api/services/ogStore.ts
@@ -5,8 +5,13 @@ const redisUrl = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_U
 const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN
 const readOnlyToken = process.env.KV_REST_API_READ_ONLY_TOKEN
 
-if (!redisUrl || !redisToken) {
-  console.error('Missing Redis credentials: UPSTASH_REDIS_REST_URL/UPSTASH_REDIS_REST_TOKEN or KV_REST_API_URL/KV_REST_API_TOKEN')
+const hasIncompleteRedisConfig = Boolean(
+  (redisUrl && !redisToken) ||
+  (!redisUrl && (redisToken || readOnlyToken))
+)
+
+if (hasIncompleteRedisConfig) {
+  console.warn('Redis cache disabled due to incomplete Redis configuration')
 }
 
 const redisWrite = redisUrl && redisToken


### PR DESCRIPTION
This PR fixes the Vercel serverless crashes on the article Open Graph endpoints by removing the relay-based metadata fetch path from the serverless runtime and using the gateway fetch path instead. It also makes the Redis cache optional so missing Upstash environment variables do not trigger noisy failures on every request.

- switch the article OG metadata path to a serverless-safe gateway fetcher
- keep the existing HTML fallback behavior when metadata is missing or invalid
- skip Redis reads and writes cleanly when cache credentials are not configured


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Article metadata extraction now reliably fetches metadata via a single gateway with multiple fallbacks, improving titles, descriptions, images, and author info shown for links.
  * Metadata fetch is abortable with a short timeout and returns null when no useful metadata is found, preventing broken previews.
  * Caching gracefully disables and skips cache reads/writes when optional cache configuration is not provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dergigi/boris/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->