### PR TITLE
fix: derive og summary from article content

### DIFF
--- a/api/services/articleMeta.ts
+++ b/api/services/articleMeta.ts
@@ -43,16 +43,20 @@ function decodeHtmlEntities(text: string): string {
 
     if (normalized.startsWith('#x')) {
       const codePoint = Number.parseInt(normalized.slice(2), 16)
-      return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint)
+      return isValidCodePoint(codePoint) ? String.fromCodePoint(codePoint) : entity
     }
 
     if (normalized.startsWith('#')) {
       const codePoint = Number.parseInt(normalized.slice(1), 10)
-      return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint)
+      return isValidCodePoint(codePoint) ? String.fromCodePoint(codePoint) : entity
     }
 
     return namedEntities[normalized] || entity
   })
+}
+
+function isValidCodePoint(codePoint: number): boolean {
+  return Number.isFinite(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
 }
 
 function stripHtml(html: string): string {
@@ -107,21 +111,51 @@ function pickArticleBodySummary(html: string, title: string): string {
   return clampSummary(summary)
 }
 
-function pickArticleAuthor(html: string, siteName: string): string {
-  const authorName = html.match(/<span(?=[^>]*\bitemprop=["']name["'])[^>]*>([\s\S]*?)<\/span>/i)
-  if (authorName?.[1]) {
-    return stripHtml(authorName[1])
+function pickNameInMarkup(markup: string): string {
+  const name = markup.match(/<span(?=[^>]*\bitemprop=["']name["'])[^>]*>([\s\S]*?)<\/span>/i)
+  if (name?.[1]) {
+    return stripHtml(name[1])
   }
 
-  const alternateName = html.match(/<span(?=[^>]*\bitemprop=["']alternateName["'])[^>]*>([\s\S]*?)<\/span>/i)
+  const alternateName = markup.match(/<span(?=[^>]*\bitemprop=["']alternateName["'])[^>]*>([\s\S]*?)<\/span>/i)
   if (alternateName?.[1]) {
     return stripHtml(alternateName[1])
   }
 
+  return ''
+}
+
+function cleanSiteName(siteName: string): string {
   return stripHtml(siteName)
     .replace(/\s*\([^)]*\)\s*on Nostr$/i, '')
     .replace(/\s+on Nostr$/i, '')
     .trim()
+}
+
+function pickArticleAuthor(html: string, siteName: string, metaAuthor: string): string {
+  const authorHeader = html.match(/<header(?=[^>]*\bitemprop=["']author["'])[^>]*>([\s\S]*?)<\/header>/i)?.[1]
+  const authorName = authorHeader ? pickNameInMarkup(authorHeader) : ''
+  if (authorName) {
+    return authorName
+  }
+
+  const relAuthor = html.match(/<a(?=[^>]*\brel=["']author["'])[^>]*>([\s\S]*?)<\/a>/i)?.[1]
+  const relAuthorName = relAuthor ? pickNameInMarkup(relAuthor) || stripHtml(relAuthor) : ''
+  if (relAuthorName) {
+    return relAuthorName
+  }
+
+  const authorFromMeta = stripHtml(metaAuthor)
+  if (authorFromMeta) {
+    return authorFromMeta
+  }
+
+  const authorFromSiteName = cleanSiteName(siteName)
+  if (authorFromSiteName) {
+    return authorFromSiteName
+  }
+
+  return pickNameInMarkup(html)
 }
 
 export async function fetchArticleMetadata(naddr: string): Promise<ArticleMetadata | null> {
@@ -171,7 +205,7 @@ export async function fetchArticleMetadata(naddr: string): Promise<ArticleMetada
         metaPattern('name', 'author')
       ])
       const siteName = pickMeta(html, [metaPattern('property', 'og:site_name')])
-      const author = pickArticleAuthor(html, siteName) || stripHtml(metaAuthor)
+      const author = pickArticleAuthor(html, siteName, metaAuthor)
 
       if (!title && !summary && !image) {
         console.log(`No OG metadata found via gateway for ${naddr}`)

--- a/api/services/articleMeta.ts
+++ b/api/services/articleMeta.ts
@@ -4,6 +4,7 @@ const DEFAULT_TITLE = 'Read on Boris'
 const DEFAULT_SUMMARY = 'Read this article on Boris'
 const DEFAULT_IMAGE = '/boris-social-1200.png'
 const DEFAULT_AUTHOR = 'Boris'
+const SUMMARY_MAX_LENGTH = 220
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -25,6 +26,102 @@ function pickMeta(html: string, patterns: RegExp[]): string {
   }
 
   return ''
+}
+
+function decodeHtmlEntities(text: string): string {
+  const namedEntities: Record<string, string> = {
+    amp: '&',
+    apos: "'",
+    gt: '>',
+    lt: '<',
+    nbsp: ' ',
+    quot: '"'
+  }
+
+  return text.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (entity, value: string) => {
+    const normalized = value.toLowerCase()
+
+    if (normalized.startsWith('#x')) {
+      const codePoint = Number.parseInt(normalized.slice(2), 16)
+      return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint)
+    }
+
+    if (normalized.startsWith('#')) {
+      const codePoint = Number.parseInt(normalized.slice(1), 10)
+      return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint)
+    }
+
+    return namedEntities[normalized] || entity
+  })
+}
+
+function stripHtml(html: string): string {
+  const text = html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<\/(p|div|h[1-6]|li|blockquote)>/gi, ' ')
+    .replace(/<br\s*\/?>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+
+  return decodeHtmlEntities(text)
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function clampSummary(text: string): string {
+  const normalized = text.replace(/\s+/g, ' ').trim()
+  if (normalized.length <= SUMMARY_MAX_LENGTH) {
+    return normalized
+  }
+
+  const truncated = normalized.slice(0, SUMMARY_MAX_LENGTH + 1)
+  const lastSpace = truncated.lastIndexOf(' ')
+  const boundary = lastSpace > SUMMARY_MAX_LENGTH * 0.7 ? lastSpace : SUMMARY_MAX_LENGTH
+
+  return `${normalized.slice(0, boundary).trim()}…`
+}
+
+function cleanTitle(title: string): string {
+  return stripHtml(title)
+    .replace(/^\((.*)\)$/, '$1')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function pickArticleHeadline(html: string): string {
+  const headline = html.match(/<h1(?=[^>]*\bitemprop=["']headline["'])[^>]*>([\s\S]*?)<\/h1>/i)
+  return headline?.[1] ? cleanTitle(headline[1]) : ''
+}
+
+function pickArticleBodySummary(html: string, title: string): string {
+  const body = html.match(/<div(?=[^>]*\bitemprop=["']articleBody["'])[^>]*>([\s\S]*?)<\/div>/i)
+  if (!body?.[1]) {
+    return ''
+  }
+
+  const paragraphs = [...body[1].matchAll(/<p[^>]*>([\s\S]*?)<\/p>/gi)]
+    .map((match) => stripHtml(match[1]))
+    .filter((paragraph) => paragraph.length > 0 && paragraph !== title)
+
+  const summary = paragraphs[0] || stripHtml(body[1])
+  return clampSummary(summary)
+}
+
+function pickArticleAuthor(html: string, siteName: string): string {
+  const authorName = html.match(/<span(?=[^>]*\bitemprop=["']name["'])[^>]*>([\s\S]*?)<\/span>/i)
+  if (authorName?.[1]) {
+    return stripHtml(authorName[1])
+  }
+
+  const alternateName = html.match(/<span(?=[^>]*\bitemprop=["']alternateName["'])[^>]*>([\s\S]*?)<\/span>/i)
+  if (alternateName?.[1]) {
+    return stripHtml(alternateName[1])
+  }
+
+  return stripHtml(siteName)
+    .replace(/\s*\([^)]*\)\s*on Nostr$/i, '')
+    .replace(/\s+on Nostr$/i, '')
+    .trim()
 }
 
 export async function fetchArticleMetadata(naddr: string): Promise<ArticleMetadata | null> {
@@ -49,27 +146,32 @@ export async function fetchArticleMetadata(naddr: string): Promise<ArticleMetada
 
       const html = await resp.text()
 
-      const title = pickMeta(html, [
+      const metaTitle = pickMeta(html, [
         metaPattern('property', 'og:title'),
         metaPattern('name', 'twitter:title'),
         /<title[^>]*>([^<]+)<\/title>/i
       ])
 
-      const summary = pickMeta(html, [
+      const title = pickArticleHeadline(html) || cleanTitle(metaTitle)
+      const metaSummary = pickMeta(html, [
         metaPattern('property', 'og:description'),
         metaPattern('name', 'twitter:description'),
         metaPattern('name', 'description')
       ])
+      const articleSummary = pickArticleBodySummary(html, title)
+      const summary = articleSummary || clampSummary(stripHtml(metaSummary))
 
       const image = pickMeta(html, [
         metaPattern('property', 'og:image'),
         metaPattern('name', 'twitter:image')
       ])
 
-      const author = pickMeta(html, [
+      const metaAuthor = pickMeta(html, [
         metaPattern('property', 'article:author'),
         metaPattern('name', 'author')
       ])
+      const siteName = pickMeta(html, [metaPattern('property', 'og:site_name')])
+      const author = pickArticleAuthor(html, siteName) || stripHtml(metaAuthor)
 
       if (!title && !summary && !image) {
         console.log(`No OG metadata found via gateway for ${naddr}`)


### PR DESCRIPTION
Improves article social previews by deriving title, description, and author from the fetched article HTML when available. This keeps the gateway fallback but prefers the actual article headline and first paragraph over thin metadata that can collapse title and description to the same short string.

- uses `itemprop="headline"` for cleaner OG titles when present
- uses the first real article paragraph for `og:description` and clamps it for preview length
- derives `article:author` from the article page before falling back to metadata

Validated with `npm run lint`, `npm run build`, and a local metadata fetch against the Relay Setup 101 article.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved article metadata extraction: titles and summaries are now derived from article headlines and body content respectively, with enhanced author information fallback handling for greater consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dergigi/boris/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->