### PR TITLE
fix: redirect the home page to explore

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,9 +34,6 @@ import { nostrverseHighlightsController } from './services/nostrverseHighlightsC
 import { nostrverseWritingsController } from './services/nostrverseWritingsController'
 import { archiveController } from './services/archiveController'
 
-const DEFAULT_ARTICLE = import.meta.env.VITE_DEFAULT_ARTICLE_NADDR || 
-  'naddr1qvzqqqr4gupzqmjxss3dld622uu8q25gywum9qtg4w4cv4064jmg20xsac2aam5nqqxnzd3cxqmrzv3exgmr2wfesgsmew'
-
 // AppRoutes component that has access to hooks
 function AppRoutes({ 
   relayPool, 
@@ -375,7 +372,7 @@ function AppRoutes({
           />
         } 
       />
-      <Route path="/" element={<Navigate to={`/a/${DEFAULT_ARTICLE}`} replace />} />
+      <Route path="/" element={<Navigate to="/explore" replace />} />
     </Routes>
   )
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,9 +1,5 @@
 /// <reference types="vite/client" />
 
-interface ImportMetaEnv {
-  readonly VITE_DEFAULT_ARTICLE_NADDR: string
-}
-
 declare module '*.svg?raw' {
   const content: string
   export default content


### PR DESCRIPTION
Redirect the root route to `/explore` so Boris opens on the explore view instead of jumping straight into the hardcoded default article. This also removes the now-unused `VITE_DEFAULT_ARTICLE_NADDR` typing since the app no longer reads that env var for the home redirect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the root navigation path (`/`) to navigate directly to the explore page instead of redirecting to a configured default article.
  * Removed unused default article environment variable configuration and related type declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->