### PR TITLE
feat: add Android Zapstore link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Boris turns your Nostr bookmarks into a calm, fast, and focused reading experien
 ## Live
 
 - App: [https://read.withboris.com/](https://read.withboris.com/)
+- Android: [Zapstore](https://zapstore.dev/apps/naddr1qqgk7un89ejx2un8d9nkjtnzdaexjucprpmhxue69uhhyetvv9uju7npwpehgmmjv5hxgetkqgsxu35yyt0mwjjh8pcz4zprhxegz69t4wr9t74vk6zne58wzh0waycrqsqqqlstkpszdr)
 
 ## The Vision
 

--- a/index.html
+++ b/index.html
@@ -10,14 +10,14 @@
     <meta name="theme-color" content="#0f172a" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <title>Boris - Read, Highlight, Explore</title>
-    <meta name="description" content="Your reading list for the Nostr world. A minimal nostr client for bookmark management with highlights." />
+    <meta name="description" content="Your reading list for the Nostr world. Read, highlight, and explore on the web or with the native Android app on Zapstore." />
     <link rel="canonical" href="https://read.withboris.com/" />
     
     <!-- Open Graph / Social Media -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://read.withboris.com/" />
     <meta property="og:title" content="Boris - Read, Highlight, Explore" />
-    <meta property="og:description" content="Your reading list for the Nostr world. A minimal nostr client for bookmark management with highlights." />
+    <meta property="og:description" content="Your reading list for the Nostr world. Read, highlight, and explore on the web or with the native Android app on Zapstore." />
     <meta property="og:image" content="https://read.withboris.com/boris-social-1200.png" />
     <meta property="og:site_name" content="Boris" />
     
@@ -25,7 +25,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://read.withboris.com/" />
     <meta name="twitter:title" content="Boris - Read, Highlight, Explore" />
-    <meta name="twitter:description" content="Your reading list for the Nostr world. A minimal nostr client for bookmark management with highlights." />
+    <meta name="twitter:description" content="Your reading list for the Nostr world. Read, highlight, and explore on the web or with the native Android app on Zapstore." />
     <meta name="twitter:image" content="https://read.withboris.com/boris-social-1200.png" />
 
     <!-- Fathom -->
@@ -41,4 +41,3 @@
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>
-

--- a/src/components/LoginOptions.tsx
+++ b/src/components/LoginOptions.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faPuzzlePiece, faShieldHalved, faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import { faPuzzlePiece, faShieldHalved, faCircleInfo, faMobileScreenButton, faUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
 import { Hooks } from 'applesauce-react'
 import { Accounts } from 'applesauce-accounts'
 import { NostrConnectSigner } from 'applesauce-signers'
 import { getDefaultBunkerPermissions } from '../services/nostrConnect'
+
+const ZAPSTORE_ANDROID_URL = 'https://zapstore.dev/apps/naddr1qqgk7un89ejx2un8d9nkjtnzdaexjucprpmhxue69uhhyetvv9uju7npwpehgmmjv5hxgetkqgsxu35yyt0mwjjh8pcz4zprhxegz69t4wr9t74vk6zne58wzh0waycrqsqqqlstkpszdr'
 
 const LoginOptions: React.FC = () => {
   const accountManager = Hooks.useAccountManager()
@@ -126,6 +128,22 @@ const LoginOptions: React.FC = () => {
         <p className="login-description">
           <mark className="login-highlight">Connect your npub</mark> to see your bookmarks, explore long-form articles, and create <mark className="login-highlight">your own highlights.</mark>
         </p>
+
+        <div className="login-android-callout">
+          <div className="login-android-copy">
+            <FontAwesomeIcon icon={faMobileScreenButton} />
+            <span>Native Android app now available.</span>
+          </div>
+          <a
+            href={ZAPSTORE_ANDROID_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="login-android-link"
+          >
+            <span>Get it on Zapstore</span>
+            <FontAwesomeIcon icon={faUpRightFromSquare} />
+          </a>
+        </div>
         
         <div className="login-buttons">
           {!showBunkerInput && (
@@ -206,4 +224,3 @@ const LoginOptions: React.FC = () => {
 }
 
 export default LoginOptions
-

--- a/src/styles/components/login.css
+++ b/src/styles/components/login.css
@@ -35,6 +35,59 @@
   font-weight: 500;
 }
 
+.login-android-callout {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  padding: 1rem;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+}
+
+.login-android-copy {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.625rem;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.login-android-copy svg {
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+
+.login-android-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: var(--min-touch-target);
+  padding: 0.75rem 1rem;
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.login-android-link:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-subtle);
+  background: var(--color-border);
+}
+
+.login-android-link svg {
+  width: 0.875rem;
+  height: 0.875rem;
+  flex-shrink: 0;
+}
+
 .login-buttons {
   display: flex;
   flex-direction: column;
@@ -258,4 +311,3 @@
     width: 100%;
   }
 }
-


### PR DESCRIPTION
Adds a small Android app callout to the Boris entry screen so visitors can install the native app from Zapstore, and refreshes public metadata and README links to mention Android availability.

- Adds a Zapstore button to the unauthenticated login screen
- Updates description metadata for search and social previews
- Adds the Android Zapstore link to the README live links


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Android app download link through Zapstore.
  * Added an Android app promotion callout to the login screen.
  * Updated page and social sharing descriptions to highlight the web and native Android reading list experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->