### PR TITLE
feat: reconstruct public X/Twitter threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ If you bookmark something on nostr, Boris will show it in the bookmarks bar. If 
 
 - Collects your saved links from Nostr and shows them as a tidy reading list
 - Opens articles in a distraction‑free reader with clear typography
+- Reconstructs public X/Twitter self-threads in chronological order when a status URL is opened
 - Shows community highlights layered on the article (yours, friends, everyone)
 - Splits zaps between you and the author(s) when you highlight
 - Lets you collapse sidebars anytime for full‑focus reading

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "test": "node --experimental-strip-types --test test/xThreadService.test.ts",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "publish:test:markdown": "./scripts/publish-markdown.sh"

--- a/src/services/readerService.ts
+++ b/src/services/readerService.ts
@@ -1,5 +1,6 @@
 // Lightweight readability-style fetcher using r.jina.ai proxy
 // Returns simplified HTML for a given URL. This avoids CORS and heavy deps.
+import { fetchXThreadContent, xStatusId } from './xThreadService'
 
 export interface ReadableContent {
   url: string
@@ -72,6 +73,20 @@ export async function fetchReadableContent(
     if (cached) return cached
   }
 
+  // X/Twitter status pages need their reply graph, not just the focal page.
+  // Keep Jina as the generic fallback when the public thread endpoint fails.
+  if (xStatusId(targetUrl)) {
+    try {
+      const thread = await fetchXThreadContent(targetUrl)
+      if (thread) {
+        saveToCache(targetUrl, thread)
+        return thread
+      }
+    } catch {
+      // Fall through to the generic readable-content proxy.
+    }
+  }
+
   const proxyUrl = toProxyUrl(targetUrl)
   const res = await fetch(proxyUrl)
   if (!res.ok) {
@@ -108,6 +123,5 @@ export async function fetchReadableContent(
   saveToCache(targetUrl, content)
   return content
 }
-
 
 

--- a/src/services/xThreadService.ts
+++ b/src/services/xThreadService.ts
@@ -2,23 +2,68 @@ import type { ReadableContent } from './readerService'
 
 const THREAD_ENDPOINT = 'https://api.fxtwitter.com/2/thread'
 
-type JsonObject = Record<string, unknown>
+interface FxAuthor {
+  id?: string
+  screenName?: string
+  name?: string
+}
 
-function asObject(value: unknown): JsonObject | null {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonObject : null
+interface FxArticle {
+  title?: string
+  blocks: string[]
+}
+
+interface FxStatus {
+  id: string
+  text: string
+  author: FxAuthor
+  parentId: string
+  article?: FxArticle
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
 }
 
 function stringValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
-function authorKey(status: JsonObject): string {
-  const author = asObject(status.author)
-  return stringValue(author?.id) || stringValue(author?.screen_name)
+function parseArticle(value: unknown): FxArticle | undefined {
+  const article = asObject(value)
+  const content = asObject(article?.content)
+  const blocks = Array.isArray(content?.blocks)
+    ? content.blocks
+      .map(block => stringValue(asObject(block)?.text))
+      .filter(Boolean)
+    : []
+  const title = stringValue(article?.title)
+  return blocks.length ? { title: title || undefined, blocks } : undefined
 }
 
-function parentId(status: JsonObject): string {
-  return stringValue(asObject(status.replying_to)?.status)
+function parseStatus(value: unknown): FxStatus | null {
+  const object = asObject(value)
+  const authorObject = asObject(object?.author)
+  const author: FxAuthor = {
+    id: stringValue(authorObject?.id) || undefined,
+    screenName: stringValue(authorObject?.screen_name) || undefined,
+    name: stringValue(authorObject?.name) || undefined
+  }
+  if (!object || !author.id && !author.screenName) return null
+
+  const id = stringValue(object.id)
+  if (!id) return null
+  return {
+    id,
+    text: stringValue(object.text),
+    author,
+    parentId: stringValue(asObject(object.replying_to)?.status),
+    article: parseArticle(object.article)
+  }
+}
+
+function authorKey(status: FxStatus): string {
+  return status.author.id || status.author.screenName || ''
 }
 
 function normalizeTweetText(text: string): string {
@@ -60,7 +105,7 @@ export function parseFxTwitterThreadPayload(
   payload: string,
   sourceUrl: string
 ): ReadableContent | null {
-  let body: JsonObject
+  let body: Record<string, unknown>
   try {
     const parsed: unknown = JSON.parse(payload)
     const object = asObject(parsed)
@@ -70,17 +115,27 @@ export function parseFxTwitterThreadPayload(
     return null
   }
 
-  const focal = asObject(body.status)
+  const focal = parseStatus(body.status)
   if (!focal) return null
   const focalAuthor = authorKey(focal)
   const focalStatusId = xStatusId(sourceUrl)
   if (!focalAuthor || !focalStatusId) return null
 
-  const statuses = new Map<string, JsonObject>()
+  const article = focal.article
+  const articleMarkdown = article?.blocks.map(normalizeTweetText).filter(Boolean).join('\n\n')
+  if (articleMarkdown) {
+    return {
+      title: article?.title || threadTitle(focal.author),
+      url: sourceUrl,
+      markdown: articleMarkdown
+    }
+  }
+
+  const statuses = new Map<string, FxStatus>()
   const thread = Array.isArray(body.thread) ? body.thread : []
   for (const value of thread) {
-    const status = asObject(value)
-    const id = stringValue(status?.id)
+    const status = parseStatus(value)
+    const id = status?.id || ''
     if (status && id) statuses.set(id, status)
   }
   const focalId = stringValue(focal.id)
@@ -89,20 +144,20 @@ export function parseFxTwitterThreadPayload(
   const ownStatuses = [...statuses.values()].filter(status => authorKey(status) === focalAuthor)
   if (ownStatuses.length === 0) return null
 
-  const statusIds = new Set(ownStatuses.map(status => stringValue(status.id)))
+  const statusIds = new Set(ownStatuses.map(status => status.id))
   const roots = ownStatuses.filter(status => {
-    const parent = parentId(status)
+    const parent = status.parentId
     return !parent || !statusIds.has(parent)
   })
-  const pending: JsonObject[][] = (roots.length ? roots : [ownStatuses[0]]).map(root => [root])
-  const completeChains: JsonObject[][] = []
+  const pending: FxStatus[][] = (roots.length ? roots : [ownStatuses[0]]).map(root => [root])
+  const completeChains: FxStatus[][] = []
 
   while (pending.length) {
     const path = pending.pop()!
-    const currentId = stringValue(path[path.length - 1].id)
-    const pathIds = new Set(path.map(status => stringValue(status.id)))
+    const currentId = path[path.length - 1].id
+    const pathIds = new Set(path.map(status => status.id))
     const children = ownStatuses.filter(candidate =>
-      !pathIds.has(stringValue(candidate.id)) && parentId(candidate) === currentId
+      !pathIds.has(candidate.id) && candidate.parentId === currentId
     )
     if (children.length === 0) {
       completeChains.push(path)
@@ -112,25 +167,25 @@ export function parseFxTwitterThreadPayload(
   }
 
   const selected = completeChains
-    .filter(chain => chain.some(status => stringValue(status.id) === focalStatusId))
+    .filter(chain => chain.some(status => status.id === focalStatusId))
     .sort((a, b) => b.length - a.length)[0]
   if (!selected) return null
 
   const markdown = selected
-    .map(status => normalizeTweetText(stringValue(status.text)))
+    .map(status => normalizeTweetText(status.text))
     .filter(Boolean)
     .join('\n\n')
   if (!markdown) return null
 
-  const author = asObject(focal.author)
-  const name = stringValue(author?.name)
-  const screenName = stringValue(author?.screen_name)
-  const authorLabel = screenName ? `@${screenName}` : ''
-  const title = name && authorLabel
-    ? `Thread by ${name} (${authorLabel})`
-    : name || authorLabel
-      ? `Thread by ${name || authorLabel}`
-      : undefined
-
+  const title = threadTitle(focal.author)
   return { title, url: sourceUrl, markdown }
+}
+
+function threadTitle(author: FxAuthor): string | undefined {
+  const authorLabel = author.screenName ? `@${author.screenName}` : ''
+  return author.name && authorLabel
+    ? `Thread by ${author.name} (${authorLabel})`
+    : author.name || authorLabel
+      ? `Thread by ${author.name || authorLabel}`
+      : undefined
 }

--- a/src/services/xThreadService.ts
+++ b/src/services/xThreadService.ts
@@ -1,0 +1,136 @@
+import type { ReadableContent } from './readerService'
+
+const THREAD_ENDPOINT = 'https://api.fxtwitter.com/2/thread'
+
+type JsonObject = Record<string, unknown>
+
+function asObject(value: unknown): JsonObject | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonObject : null
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function authorKey(status: JsonObject): string {
+  const author = asObject(status.author)
+  return stringValue(author?.id) || stringValue(author?.screen_name)
+}
+
+function parentId(status: JsonObject): string {
+  return stringValue(asObject(status.replying_to)?.status)
+}
+
+function normalizeTweetText(text: string): string {
+  return text
+    .replace(/[\u2028\u2029]/g, '\n')
+    .split('\n')
+    .map(line => line.replace(/[\t ]+/g, ' ').trim())
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+export function xStatusId(sourceUrl: string): string | null {
+  try {
+    const url = new URL(sourceUrl)
+    const host = url.hostname.toLowerCase().replace(/^www\./, '')
+    if (host !== 'x.com' && host !== 'twitter.com') return null
+    return url.pathname.match(/^\/[^/]+\/status\/(\d+)/i)?.[1] || null
+  } catch {
+    return null
+  }
+}
+
+export async function fetchXThreadContent(
+  sourceUrl: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<ReadableContent | null> {
+  const statusId = xStatusId(sourceUrl)
+  if (!statusId) return null
+
+  const response = await fetchImpl(`${THREAD_ENDPOINT}/${statusId}`, {
+    headers: { accept: 'application/json' }
+  })
+  if (!response.ok) throw new Error(`Failed to fetch X thread (${response.status})`)
+  return parseFxTwitterThreadPayload(await response.text(), sourceUrl)
+}
+
+export function parseFxTwitterThreadPayload(
+  payload: string,
+  sourceUrl: string
+): ReadableContent | null {
+  let body: JsonObject
+  try {
+    const parsed: unknown = JSON.parse(payload)
+    const object = asObject(parsed)
+    if (!object) return null
+    body = object
+  } catch {
+    return null
+  }
+
+  const focal = asObject(body.status)
+  if (!focal) return null
+  const focalAuthor = authorKey(focal)
+  const focalStatusId = xStatusId(sourceUrl)
+  if (!focalAuthor || !focalStatusId) return null
+
+  const statuses = new Map<string, JsonObject>()
+  const thread = Array.isArray(body.thread) ? body.thread : []
+  for (const value of thread) {
+    const status = asObject(value)
+    const id = stringValue(status?.id)
+    if (status && id) statuses.set(id, status)
+  }
+  const focalId = stringValue(focal.id)
+  if (focalId && !statuses.has(focalId)) statuses.set(focalId, focal)
+
+  const ownStatuses = [...statuses.values()].filter(status => authorKey(status) === focalAuthor)
+  if (ownStatuses.length === 0) return null
+
+  const statusIds = new Set(ownStatuses.map(status => stringValue(status.id)))
+  const roots = ownStatuses.filter(status => {
+    const parent = parentId(status)
+    return !parent || !statusIds.has(parent)
+  })
+  const pending: JsonObject[][] = (roots.length ? roots : [ownStatuses[0]]).map(root => [root])
+  const completeChains: JsonObject[][] = []
+
+  while (pending.length) {
+    const path = pending.pop()!
+    const currentId = stringValue(path[path.length - 1].id)
+    const pathIds = new Set(path.map(status => stringValue(status.id)))
+    const children = ownStatuses.filter(candidate =>
+      !pathIds.has(stringValue(candidate.id)) && parentId(candidate) === currentId
+    )
+    if (children.length === 0) {
+      completeChains.push(path)
+    } else {
+      for (const child of [...children].reverse()) pending.push([...path, child])
+    }
+  }
+
+  const selected = completeChains
+    .filter(chain => chain.some(status => stringValue(status.id) === focalStatusId))
+    .sort((a, b) => b.length - a.length)[0]
+  if (!selected) return null
+
+  const markdown = selected
+    .map(status => normalizeTweetText(stringValue(status.text)))
+    .filter(Boolean)
+    .join('\n\n')
+  if (!markdown) return null
+
+  const author = asObject(focal.author)
+  const name = stringValue(author?.name)
+  const screenName = stringValue(author?.screen_name)
+  const authorLabel = screenName ? `@${screenName}` : ''
+  const title = name && authorLabel
+    ? `Thread by ${name} (${authorLabel})`
+    : name || authorLabel
+      ? `Thread by ${name || authorLabel}`
+      : undefined
+
+  return { title, url: sourceUrl, markdown }
+}

--- a/test/xThreadService.test.ts
+++ b/test/xThreadService.test.ts
@@ -44,6 +44,36 @@ test('accepts x.com and twitter.com status URLs only', () => {
   assert.equal(xStatusId('https://example.com/status/789'), null)
 })
 
+test('prefers readable X Article blocks over thread text', () => {
+  const payload = JSON.stringify({
+    status: {
+      id: '300',
+      text: 'Article preview text',
+      author: { id: 'author-3', name: 'Writer', screen_name: 'writer' },
+      article: {
+        title: 'Long-form article',
+        content: {
+          blocks: [
+            { type: 'unstyled', text: 'The article body.' },
+            { type: 'unstyled', text: 'A second paragraph.' }
+          ]
+        }
+      }
+    },
+    thread: [{
+      id: '301',
+      text: 'This thread text should not win.',
+      author: { id: 'author-3' },
+      replying_to: { status: '300' }
+    }]
+  })
+
+  const content = parseFxTwitterThreadPayload(payload, 'https://x.com/writer/status/300')
+
+  assert.equal(content?.title, 'Long-form article')
+  assert.equal(content?.markdown, 'The article body.\n\nA second paragraph.')
+})
+
 test('rejects malformed payloads without a readable focal status', () => {
   assert.equal(parseFxTwitterThreadPayload('{"status":null}', 'https://x.com/example/status/1'), null)
 })

--- a/test/xThreadService.test.ts
+++ b/test/xThreadService.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { parseFxTwitterThreadPayload, xStatusId } from '../src/services/xThreadService.ts'
+
+test('reconstructs the focal author chain in reply order', () => {
+  const payload = JSON.stringify({
+    status: {
+      id: '100',
+      text: 'Opening paragraph.\n\nThread introduction.',
+      lang: 'en',
+      author: { id: 'author-1', name: 'Example Author', screen_name: 'example' }
+    },
+    thread: [
+      {
+        id: 'noise',
+        text: 'A side reply must not be read.',
+        author: { id: 'other-author', name: 'Other', screen_name: 'other' },
+        replying_to: { status: '100' }
+      },
+      {
+        id: '102',
+        text: '2/ Second continuation.',
+        author: { id: 'author-1' },
+        replying_to: { status: '101' }
+      },
+      {
+        id: '101',
+        text: '1/ First continuation.',
+        author: { id: 'author-1', name: 'Example Author', screen_name: 'example' },
+        replying_to: { status: '100' }
+      }
+    ]
+  })
+
+  const content = parseFxTwitterThreadPayload(payload, 'https://x.com/example/status/100')
+
+  assert.equal(content?.title, 'Thread by Example Author (@example)')
+  assert.equal(content?.markdown, 'Opening paragraph.\n\nThread introduction.\n\n1/ First continuation.\n\n2/ Second continuation.')
+})
+
+test('accepts x.com and twitter.com status URLs only', () => {
+  assert.equal(xStatusId('https://x.com/example/status/123'), '123')
+  assert.equal(xStatusId('https://twitter.com/example/status/456'), '456')
+  assert.equal(xStatusId('https://example.com/status/789'), null)
+})
+
+test('rejects malformed payloads without a readable focal status', () => {
+  assert.equal(parseFxTwitterThreadPayload('{"status":null}', 'https://x.com/example/status/1'), null)
+})


### PR DESCRIPTION
## Summary

Closes #75

Port the thread-reading behavior from mytts into Boris while preserving Boris' existing generic Jina reader fallback.

- Detect public `x.com/.../status/<id>` and `twitter.com/.../status/<id>` URLs.
- Fetch the public thread through FxTwitter without login, cookies, or private credentials.
- Prefer readable X Article `content.blocks[].text` when present.
- Otherwise filter to the focal author, follow `replying_to.status`, choose the longest chain containing the focal post, and preserve paragraph breaks.
- Return the reconstructed thread as Boris `ReadableContent.markdown`, so the existing reader, highlights, cache, and browser TTS flow continue to work.
- Fall back to the current Jina reader when thread retrieval fails or the payload is malformed.

## Validation

- TDD: added focused tests for article precedence, ordering, author filtering, URL detection, and malformed payloads.
- `npm test`
- `npm run lint`
- `npm run build`
- Live smoke test through the ported service passed for all requested URLs:
  - `a_libutti`: 3-post response
  - `DisinfoLab`: 18-post response
  - `Jeffar_AI`: 17-post response

The implementation is intentionally limited to public status URLs and keeps the existing generic reader path as the fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reconstructing public X/Twitter self-threads chronologically when opening a status URL.
  * Thread content is converted into readable Markdown with title and source metadata.
  * Supports links from both x.com and twitter.com.
  * Added support for extracting X Article content when available.

* **Bug Fixes**
  * Falls back to standard content retrieval when thread data is unavailable or invalid.

* **Tests**
  * Added coverage for thread ordering, URL validation, article extraction, side-reply exclusion, and malformed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->